### PR TITLE
Fixes create command waiting forever for container

### DIFF
--- a/commands
+++ b/commands
@@ -43,7 +43,7 @@ case "$1" in
     echo "$ID" > "$SERVICE_ROOT/ID"
 
     dokku_log_verbose_quiet "Waiting for container to be ready"
-    docker run --rm --link "$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX" aanand/wait > /dev/null
+    docker run --rm --link "$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX" martin/wait > /dev/null
 
     dokku_log_info2 "$PLUGIN_SERVICE container created: $SERVICE"
     dokku "$PLUGIN_COMMAND_PREFIX:info" "$SERVICE"


### PR DESCRIPTION
##### `dokku elasticsearch:create foo` waits for container to come up forever.

Elasticsearch exposed two ports `9200` and `9300` original docker-wait is [unable](https://github.com/aanand/docker-wait/blob/master/wait) to handle that and waits forever. Tested on fresh ubuntu 14.04.3, docker 1.8.2, dokku 0.4.0.