### PR TITLE
Fix strage exit codes with docker exec

### DIFF
--- a/functions
+++ b/functions
@@ -58,7 +58,7 @@ retry-docker-command() {
   local ID="$1" COMMAND="$2"
   local i=0 success=false
   until [ $i -ge 100 ]; do
-    set +e; docker exec -it "$ID" bash -c "$COMMAND" 2> /dev/null; exit_code=$? ; set -e
+    set +e; docker exec -it "$ID" sh -c "$COMMAND" 2> /dev/null; exit_code=$? ; set -e
     if [[ "$exit_code" == 0 ]]; then
       success=true
       break


### PR DESCRIPTION
Replaceing bash with sh works

https://github.com/docker/compose/issues/3379

Fixes #44.