### PR TITLE
WIP: Support installing Elasticsearch 5.x without the pain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ env:
   - DOKKU_VERSION=v0.6.0 DOKKU_SYSTEM_GROUP=travis DOKKU_SYSTEM_USER=travis
   - DOKKU_VERSION=v0.5.0 DOKKU_SYSTEM_GROUP=travis DOKKU_SYSTEM_USER=travis
   - DOKKU_VERSION=v0.4.0 DOKKU_SYSTEM_GROUP=travis DOKKU_SYSTEM_USER=travis
+before_script:
+  - sudo sysctl -w vm.max_map_count=262144
 script: make test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # dokku elasticsearch [![Build Status](https://img.shields.io/travis/dokku/dokku-elasticsearch.svg?branch=master "Build Status")](https://travis-ci.org/dokku/dokku-elasticsearch) [![IRC Network](https://img.shields.io/badge/irc-freenode-blue.svg "IRC Freenode")](https://webchat.freenode.net/?channels=dokku)
 
 Official elasticsearch plugin for dokku. Currently defaults to installing [elasticsearch 2.3.5](https://hub.docker.com/_/elasticsearch/).
+It's possible to install Elasticsearch 5.x, but it does require some manual setup. 
 
 ## requirements
 
@@ -12,6 +13,17 @@ Official elasticsearch plugin for dokku. Currently defaults to installing [elast
 ```shell
 # on 0.4.x+
 sudo dokku plugin:install https://github.com/dokku/dokku-elasticsearch.git elasticsearch
+```
+
+If you want to run elasticsearch 5.x, there's a requirement to increase the `vm.max_map_count`
+value in `/etc/sysctl.conf`.
+
+```shell
+# add or update: vm.max_map_count = 262144
+vi /etc/sysctl.conf
+
+# load the change variables from /etc/sysctl.conf
+sysctl -p 
 ```
 
 ## commands
@@ -61,6 +73,13 @@ dokku elasticsearch:create lolipop
 # official elasticsearch image
 export ELASTICSEARCH_IMAGE="elasticsearch"
 export ELASTICSEARCH_IMAGE_VERSION="1.6.2"
+dokku elasticsearch:create lolipop
+
+# if you want to use elasticsearch 5.x, you
+# will need to increase `vm.max_map_count` in 
+# /etc/sysctl.conf. See #install
+export ELASTICSEARCH_IMAGE="elasticsearch"
+export ELASTICSEARCH_IMAGE_VERSION="5.6.12"
 dokku elasticsearch:create lolipop
 
 # you can also specify custom environment
@@ -180,3 +199,22 @@ OR
 If you wish to disable the `docker pull` calls that the plugin triggers, you may set the `ELASTICSEARCH_DISABLE_PULL` environment variable to `true`. Once disabled, you will need to pull the service image you wish to deploy as shown in the `stderr` output.
 
 Please ensure the proper images are in place when `docker pull` is disabled.
+
+## JVM Settings
+
+In order to get out-of-the-box working deployments of elasticsearch the maximum 
+memory allocation of the JVM is limited to 512m. You can change this in 
+`/var/lib/dokku/services/elasticsearch/<service>/config/jvm.options`. 
+
+The following example changes the initial (`-Xms`) and maximum (`-Xmx`) memory
+allocations for the JVM from 512m to 2g. 
+
+```
+# -Xms512m
+# -Xmx512m
+-Xms2g
+-Xmx2g
+```
+
+After making this change, make sure to restart your container with 
+`dokku elasticsearch:restart`. 

--- a/functions
+++ b/functions
@@ -26,6 +26,8 @@ service_create() {
 
   service_parse_args "${@:2}"
 
+  service_check_sysctl
+
   if ! service_image_exists "$SERVICE"; then
     if [[ "$PLUGIN_DISABLE_PULL" == "true" ]]; then
       dokku_log_warn "${PLUGIN_DISABLE_PULL_VARIABLE} environment variable detected. Not running pull command." 1>&2
@@ -136,4 +138,13 @@ service_url() {
   local SERVICE="$1"
   local SERVICE_DNS_HOSTNAME="$(service_dns_hostname "$SERVICE")"
   echo "$PLUGIN_SCHEME://$SERVICE_DNS_HOSTNAME:${PLUGIN_DATASTORE_PORTS[0]}"
+}
+
+service_check_sysctl() {
+  local VM_MAX_MAP_COUNT_CURRENT=$(sysctl -n vm.max_map_count)
+  local VM_MAX_MAP_COUNT_REQUIRED=262144
+
+  if [ "$VM_MAX_MAP_COUNT_CURRENT" -lt "$VM_MAX_MAP_COUNT_REQUIRED" ]; then
+    dokku_log_fail "Please update /etc/systctl.conf with 'vm.max_map_count = 262144' to accommodate Elasticsearch."
+  fi
 }

--- a/functions
+++ b/functions
@@ -64,6 +64,7 @@ service_create_container() {
   dokku_log_info2 "Copying config files into place"
   retry-docker-command "$ID" "cp -arfp --no-clobber /etc/elasticsearch/. /usr/share/elasticsearch/config/"
   retry-docker-command "$ID" "echo 'network.host: 0.0.0.0' >> /usr/share/elasticsearch/config/elasticsearch.yml"
+  retry-docker-command "$ID" "sed -i.bak 's#Xms2g#Xms512m#g; s#Xmx2g#Xmx512m#g' /usr/share/elasticsearch/config/jvm.options"
   retry-docker-command "$ID" "rm -rf /etc/elasticsearch && ln -sfn /usr/share/elasticsearch/config /etc/elasticsearch"
   retry-docker-command "$ID" "chown -R root:elasticsearch /etc/elasticsearch"
   docker restart "$ID" > /dev/null

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -32,4 +32,4 @@ if [[ ! -f $BIN_STUBS/plugn ]]; then
   find "$DOKKU_ROOT/plugins" -mindepth 1 -maxdepth 1 -type d ! -name 'available' ! -name 'enabled' -exec ln -s {} "$DOKKU_ROOT/plugins/enabled" \;
 fi
 
-sysctl -w vm.max_map_count=262144
+sudo sysctl -w vm.max_map_count=262144

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -31,3 +31,5 @@ if [[ ! -f $BIN_STUBS/plugn ]]; then
   find "$DOKKU_ROOT/plugins" -mindepth 1 -maxdepth 1 -type d ! -name 'available' ! -name 'enabled' -exec ln -s {} "$DOKKU_ROOT/plugins/available" \;
   find "$DOKKU_ROOT/plugins" -mindepth 1 -maxdepth 1 -type d ! -name 'available' ! -name 'enabled' -exec ln -s {} "$DOKKU_ROOT/plugins/enabled" \;
 fi
+
+sysctl -w vm.max_map_count=262144

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -4,9 +4,6 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_helper.bash"
 
 BIN_STUBS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/bin"
 
-sudo sysctl -w vm.max_map_count=262144
-sudo sysctl vm.max_map_count
-
 if [[ ! -d $DOKKU_ROOT ]]; then
   git clone https://github.com/progrium/dokku.git $DOKKU_ROOT > /dev/null
 fi

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -4,6 +4,9 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test_helper.bash"
 
 BIN_STUBS="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/bin"
 
+sudo sysctl -w vm.max_map_count=262144
+sudo sysctl vm.max_map_count
+
 if [[ ! -d $DOKKU_ROOT ]]; then
   git clone https://github.com/progrium/dokku.git $DOKKU_ROOT > /dev/null
 fi
@@ -32,4 +35,3 @@ if [[ ! -f $BIN_STUBS/plugn ]]; then
   find "$DOKKU_ROOT/plugins" -mindepth 1 -maxdepth 1 -type d ! -name 'available' ! -name 'enabled' -exec ln -s {} "$DOKKU_ROOT/plugins/enabled" \;
 fi
 
-sudo sysctl -w vm.max_map_count=262144


### PR DESCRIPTION
See #53 for a more detailed discussion of this PR. This PR tackles the following:

 - [x] 1. Warning the user when creating a new elasticsearch container about the `vm.max_map_count` setting if it's not correct (e.g. < 262144, according to Elasticsearch docs).
 - [x] 2. Sets the JVM memory allocation maximum to 512m from 2g. This should reduce failed starts on low memory machines. 
 - [x]  3. Updates to the README to ellaborate on the above and give proper instructions for people seeking to install Elasticsearch 5.x
 - [ ] 4. Test setting up a 5.x container succesfully

Things that can be improved (input and code welcome!)

 - [ ] Only perform the `vm.max_map_count` check when actually installing a 5.x version of elasticsearch. 
 - [x] Get Travis to accept the sysctl command correctly if possible, or add a work-around for the tests. The previous item might be a solution, as all tests are run against 