### PR TITLE
Add `node.master: true` to config file

### DIFF
--- a/templates/7-config.yml.sigil
+++ b/templates/7-config.yml.sigil
@@ -1,4 +1,5 @@
 node.name: {{ $.SERVICE_NAME }}-1
+node.master: true
 cluster.name: {{ $.SERVICE_NAME }}-cluster
 network.host: 0.0.0.0
 cluster.initial_master_nodes:


### PR DESCRIPTION
We experienced a massive consumption of RAM (~16G with an empty index) from the elasticsearch container w/o this option. AFAIK on a dokku deployment having only a master node makes sense.

Not tested on v8 so only proposing a patch on v7.

NB: tested on 7.14.1