### PR TITLE
docs: Clarify that the memory limit is in megabytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ flags:
 - `-C|--custom-env "USER=alpha;HOST=beta"`: semi-colon delimited environment variables to start the service with
 - `-i|--image IMAGE`: the image name to start the service with
 - `-I|--image-version IMAGE_VERSION`: the image version to start the service with
-- `-m|--memory MEMORY`: container memory limit (default: unlimited)
+- `-m|--memory MEMORY`: container memory limit in megabytes (default: unlimited)
 - `-p|--password PASSWORD`: override the user-level service password
 - `-r|--root-password PASSWORD`: override the root-level service password
 - `-s|--shm-size SHM_SIZE`: override shared memory size for elasticsearch docker container

--- a/subcommands/clone
+++ b/subcommands/clone
@@ -14,7 +14,7 @@ service-clone-cmd() {
   #F -C|--custom-env "USER=alpha;HOST=beta", semi-colon delimited environment variables to start the service with
   #F -i|--image IMAGE, the image name to start the service with
   #F -I|--image-version IMAGE_VERSION, the image version to start the service with
-  #F -m|--memory MEMORY, container memory limit (default: unlimited)
+  #F -m|--memory MEMORY, container memory limit in megabytes (default: unlimited)
   #F -p|--password PASSWORD, override the user-level service password
   #F -r|--root-password PASSWORD, override the root-level service password
   #F -s|--shm-size SHM_SIZE, override shared memory size for $PLUGIN_COMMAND_PREFIX docker container

--- a/subcommands/create
+++ b/subcommands/create
@@ -22,7 +22,7 @@ service-create-cmd() {
   #F -C|--custom-env "USER=alpha;HOST=beta", semi-colon delimited environment variables to start the service with
   #F -i|--image IMAGE, the image name to start the service with
   #F -I|--image-version IMAGE_VERSION, the image version to start the service with
-  #F -m|--memory MEMORY, container memory limit (default: unlimited)
+  #F -m|--memory MEMORY, container memory limit in megabytes (default: unlimited)
   #F -p|--password PASSWORD, override the user-level service password
   #F -r|--root-password PASSWORD, override the root-level service password
   #F -s|--shm-size SHM_SIZE, override shared memory size for $PLUGIN_COMMAND_PREFIX docker container


### PR DESCRIPTION
When creating the container memory limit "m" is specified in the creation
command so this value must be specified in megabytes.