### PR TITLE
feat: respect DOKKU_LIB_HOST_ROOT for mounted data volumes

### DIFF
--- a/config
+++ b/config
@@ -3,7 +3,8 @@ _DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export ELASTICSEARCH_IMAGE=${ELASTICSEARCH_IMAGE:="$(awk -F '[ :]' '{print $2}' "${_DIR}/Dockerfile")"}
 export ELASTICSEARCH_IMAGE_VERSION=${ELASTICSEARCH_IMAGE_VERSION:="$(awk -F '[ :]' '{print $3}' "${_DIR}/Dockerfile")"}
 export ELASTICSEARCH_ROOT=${ELASTICSEARCH_ROOT:="$DOKKU_LIB_ROOT/services/elasticsearch"}
-export ELASTICSEARCH_HOST_ROOT=${ELASTICSEARCH_HOST_ROOT:=$ELASTICSEARCH_ROOT}
+export DOKKU_LIB_HOST_ROOT=${DOKKU_LIB_HOST_ROOT:=$DOKKU_LIB_ROOT}
+export ELASTICSEARCH_HOST_ROOT=${ELASTICSEARCH_HOST_ROOT:="$DOKKU_LIB_HOST_ROOT/services/elasticsearch"}
 
 export PLUGIN_UNIMPLEMENTED_SUBCOMMANDS=("backup" "backup-auth" "backup-deauth" "backup-schedule" "backup-schedule-cat" "backup-set-encryption" "backup-unschedule" "backup-unset-encryption" "clone" "connect" "export" "import")
 export PLUGIN_COMMAND_PREFIX="elasticsearch"


### PR DESCRIPTION
This change allows folks to change where dokku mounts data from for all official plugins, removing the need to specify the configuration on a one-off basis.

Refs dokku/dokku#5468