### PR TITLE
fix: drop discovery-type from es9 config

### DIFF
--- a/templates/9-config.yml.sigil
+++ b/templates/9-config.yml.sigil
@@ -3,4 +3,3 @@ cluster.name: {{ $.SERVICE_NAME }}-cluster
 network.host: 0.0.0.0
 cluster.initial_master_nodes:
   - {{ $.SERVICE_NAME }}-1
-discovery.type: single-node


### PR DESCRIPTION
It is not compatible with cluster.initial_master_nodes.